### PR TITLE
Updated to support breaking change from 08f8141

### DIFF
--- a/WebStorageCookieStore.js
+++ b/WebStorageCookieStore.js
@@ -24,7 +24,7 @@ class WebStorageCookieStore extends ToughCookie.Store {
     callback(null, Cookie.fromJSON(cookie));
   }
 
-  findCookies(domain, path, callback) {
+  findCookies(domain, path, allowSpecialUseDomain, callback) {
     if (!domain) {
       callback(null, []);
       return;


### PR DESCRIPTION
https://github.com/salesforce/tough-cookie/commit/08f81419c5beaaa8d076c9eb062f628f258525ae broke this library, and on newer versions the callback parameter became the allowSpecialUseDomain. This PR fixes compatibility with newer versions.